### PR TITLE
Add av codec members

### DIFF
--- a/avcodec/codec.go
+++ b/avcodec/codec.go
@@ -90,6 +90,17 @@ func (c *Codec) LongName() string {
 	return C.GoString(c.long_name)
 }
 
+// PixFmts returns an array of support pixel format, see AV_PIX_FMT_xxx.
+//
+// C-Field: AVCodec::pix_fmts
+func (c *Codec) PixFmts() []avutil.PixelFormat {
+	arr := (*[1 << 30]avutil.PixelFormat)(unsafe.Pointer(c.pix_fmts))
+	var len int
+	for len = 0; arr[len] != -1; len++ {
+	}
+	return arr[:len:len]
+}
+
 // SampleFmts returns the suppoted sample formats.
 //
 // C-Variable: AVCodec::sample_fmts

--- a/avcodec/context.go
+++ b/avcodec/context.go
@@ -238,6 +238,15 @@ func RegisterCodecParser(p *CodecParser) {
 }
 
 // FromParameters fills the previously initializes CodecContext with the given parameters.
+// C-Function: avcodec_parameters_to_context
 func (ctxt *CodecContext) FromParameters(par *CodecParameters) avutil.ReturnCode {
 	return avutil.NewReturnCode(int(C.avcodec_parameters_to_context((*C.AVCodecContext)(ctxt), (*C.AVCodecParameters)(par))))
+}
+
+// ToParameters returns a CodecParameters instance from a CodecContext
+// C-Function: avcodec_parameters_from_contex
+func (ctxt *CodecContext) ToParameters() (*CodecParameters, avutil.ReturnCode) {
+	par := &CodecParameters{}
+	ret := int(C.avcodec_parameters_from_context((*C.AVCodecParameters)(par), (*C.AVCodecContext)(ctxt)))
+	return par, avutil.NewReturnCode(ret)
 }

--- a/avcodec/context_struct.go
+++ b/avcodec/context_struct.go
@@ -1384,6 +1384,28 @@ func (ctxt *CodecContext) SetRequestSampleFmt(fmt avutil.SampleFormat) {
 	ctxt.request_sample_fmt = C.enum_AVSampleFormat(fmt)
 }
 
+// SampleAspectRatio returns the sample aspect ratio.
+//
+// sample aspect ratio (0 if unknown) That is the width of a pixel divided by the height of the pixel.
+//
+// Numerator and denominator must be relatively prime and smaller than 256 for some video standards.
+//
+// C-Field: AVCodecContext::sample_aspect_ratio
+func (ctxt *CodecContext) SampleAspectRatio() Rational {
+	return (Rational)(ctxt.sample_aspect_ratio)
+}
+
+// SetSampleAspectRatio sets the sample aspect ratio.
+//
+// sample aspect ratio (0 if unknown) That is the width of a pixel divided by the height of the pixel.
+//
+// Numerator and denominator must be relatively prime and smaller than 256 for some video standards.
+//
+// C-Field: AVCodecContext::sample_aspect_ratio
+func (ctxt *CodecContext) SetSampleAspectRatio(v Rational) {
+	ctxt.sample_aspect_ratio = (C.struct_AVRational)(v)
+}
+
 // SampleFmt returns the audio sample format.
 //
 // C-Field: AVCodecContext::sample_fmt

--- a/avcodec/context_struct.go
+++ b/avcodec/context_struct.go
@@ -134,6 +134,13 @@ func (ctxt *CodecContext) Channels() int {
 	return int(ctxt.channels)
 }
 
+// SetChannels sets the number of audio channels.
+//
+// C-Field: AVCodecContext::channels
+func (ctxt *CodecContext) SetChannels(c int) {
+	ctxt.channels = C.int(c)
+}
+
 // CodedHeight returns the bitstream height.
 //
 // C-Field: AVCodecContext::coded_height

--- a/avcodec/context_struct.go
+++ b/avcodec/context_struct.go
@@ -141,6 +141,20 @@ func (ctxt *CodecContext) SetChannels(c int) {
 	ctxt.channels = C.int(c)
 }
 
+// ChannelLayout returns the audio channel layout.
+//
+// C-Field: AVCodecContext::channel_layout
+func (ctxt *CodecContext) ChannelLayout() uint64 {
+	return uint64(ctxt.channel_layout)
+}
+
+// SetChannelLayout sets the audio channel layout.
+//
+// C-Field: AVCodecContext::channel_layout
+func (ctxt *CodecContext) SetChannelLayout(c uint64) {
+	ctxt.channel_layout = C.uint64_t(c)
+}
+
 // CodedHeight returns the bitstream height.
 //
 // C-Field: AVCodecContext::coded_height

--- a/avcodec/context_struct.go
+++ b/avcodec/context_struct.go
@@ -1190,6 +1190,56 @@ func (ctxt *CodecContext) SetThreadType(v int) {
 	ctxt.thread_type = C.int(v)
 }
 
+// TimeBase returns the unit of time (in seconds).
+//
+// This is the fundamental unit of time (in seconds) in terms
+// of which frame timestamps are represented. For fixed-fps content,
+// timebase should be 1/framerate and timestamp increments should be
+// identically 1.
+// This often, but not always is the inverse of the frame rate or field rate
+// for video. 1/time_base is not the average frame rate if the frame rate is not
+// constant.
+//
+// Like containers, elementary streams also can store timestamps, 1/time_base
+// is the unit in which these timestamps are specified.
+// As example of such codec time base see ISO/IEC 14496-2:2001(E)
+// vop_time_increment_resolution and fixed_vop_rate
+// (fixed_vop_rate == 0 implies that it is different from the framerate)
+//
+//  - encoding: MUST be set by user.
+// - decoding: the use of this field for decoding is deprecated.
+//            Use framerate instead.
+//
+// C-Field: AVCodecContext::time_base
+func (ctxt *CodecContext) TimeBase() Rational {
+	return (Rational)(ctxt.time_base)
+}
+
+// SetTimeBase sets the unit of time (in seconds).
+//
+// This is the fundamental unit of time (in seconds) in terms
+// of which frame timestamps are represented. For fixed-fps content,
+// timebase should be 1/framerate and timestamp increments should be
+// identically 1.
+// This often, but not always is the inverse of the frame rate or field rate
+// for video. 1/time_base is not the average frame rate if the frame rate is not
+// constant.
+//
+// Like containers, elementary streams also can store timestamps, 1/time_base
+// is the unit in which these timestamps are specified.
+// As example of such codec time base see ISO/IEC 14496-2:2001(E)
+// vop_time_increment_resolution and fixed_vop_rate
+// (fixed_vop_rate == 0 implies that it is different from the framerate)
+//
+//  - encoding: MUST be set by user.
+// - decoding: the use of this field for decoding is deprecated.
+//            Use framerate instead.
+//
+// C-Field: AVCodecContext::time_base
+func (ctxt *CodecContext) SetTimeBase(v Rational) {
+	ctxt.time_base = (C.struct_AVRational)(v)
+}
+
 // TicksPerFrame returns the ticks per frame.
 //
 // For some codecs, the time base is closer to the field rate than the frame rate.


### PR DESCRIPTION
This adds several members to avcodec.

I will have additional members to add as I continue to port the examples from ffmpeg. I'll issue a separate pull request for the examples, once they have been validated.

Do you prefer smaller pull request for each function I add, or would you rather I group it into a large pull request with all the changes?